### PR TITLE
Adding an option to node-slip to use a less strict interpretation of RFC 1055

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ functions: data, framing and escape. Here's a very simple example:
 
 Now instantiate a slip parser like so:
 
-<pre>    var parser = new slip.parser( receiver );</pre>
+<pre>    var parser = new slip.parser( receiver, strict );</pre>
+
+(strict is a bool that will mandate SLIP packets begin and end with the END character if set to true.  It defaults to true.)
 
 And start sending the parser some data:
 

--- a/node-slip.js
+++ b/node-slip.js
@@ -28,9 +28,15 @@
 	}
     };
 
-    function slip_parser( receiver ) {
+    function slip_parser( receiver, strict ) {
+	if (typeof strict === "undefined" || strict === null)
+		strict = true
 	this.receiver = receiver;
-	this.state = slip_parser.STATE_OUT;
+	if ( strict )
+		this.state = slip_parser.STATE_OUT;
+	else
+		this.state = slip_parser.STATE_IN;
+	this.strict = strict;
 	this.data = new slip_buffer( 16 );
 	this.error = new slip_buffer( 16 );
     }
@@ -53,7 +59,8 @@
 	    case slip_parser.STATE_IN:
 		switch( input_buffer[i] ) {
 		case slip_parser.CHAR_END:
-		    this.state = slip_parser.STATE_OUT;
+			if ( this.strict )
+				this.state = slip_parser.STATE_OUT;
 		    this.data.contentsAndReset( this.receiver, this.receiver.data );
 		    break;
 		case slip_parser.CHAR_ESC:


### PR DESCRIPTION
The way this was coded, it expected all SLIP packets to start with END.
 I was getting framing errors with a SLIP implementation I'm working
with that doesn't begin its packets with END.

According to RFC 1055 that defines SLIP, it is not mandatory for
packets to start with END; it was only Phil Karn's suggestion they do
so.  Two back-to-back END packets are fine, but not necessary.

I've added a strict argument to slip_parser that defaults to true for
backwards compatibility.  If it's set to false, it turns off the
requirement for SLIP packets to start with the END character.

There should be no behavioral change for existing code with this
change; only code with strict set to false will see a change.
